### PR TITLE
config exported 

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ var entryFactory = require("./lib/entry-factory.js"),
 
 
 function defineTasks(gulp, config) {
+    if (typeof config === 'undefined') {
+        config = defineTasks.config;
+    }
     var paths = config.paths,
         bundleIt = function(entry, target) {
             return function() {
@@ -195,4 +198,20 @@ function defineTasks(gulp, config) {
     });
 }
 
+var defaultConfig = {
+  paths: {
+    bower: [
+      'bower_components/purescript-*/src/**/*.purs',
+      'bower_components/purescript-*/purescript-*/src/**/*.purs'
+    ],
+    src: ['src/**/*.purs'],
+    test: ['test/**/*.purs']
+  },
+  tmpDir: 'dist'
+};
+
+
 module.exports = defineTasks;
+module.exports.config = defaultConfig;
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mandragora-bucket",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Bunch of gulp tasks for purescript projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fixes #4 

@puffnfresh now you can use something like 

``` javascript
var mb = require("mandragora-bucket"),
    gulp = require("gulp");
// for default
mb(gulp);
// get defaultConfig
console.log(mb.config);
// you can provide your own config 
mb(gulp, {paths: {...}, tmp: "dist"});
// you can modify config field
mb.config.tmp = "out";
mb(gulp);
```
